### PR TITLE
Possible fix for #7

### DIFF
--- a/src/main/scala/scala/sprinter/printers/PrettyPrinters.scala
+++ b/src/main/scala/scala/sprinter/printers/PrettyPrinters.scala
@@ -710,7 +710,7 @@ class PrettyPrinters(val global: Global) {
     }
 
     //Danger: it's overwritten method - can be problems with inheritance)
-    def symName(tree: Tree, name: Name, decoded: Boolean = false): String =
+    def symName(tree: Tree, name: Name, decoded: Boolean = true): String =
       if (compareNames(name, nme.CONSTRUCTOR)) "this"
       else quotedName(name, decoded)
 


### PR DESCRIPTION
This seems to fix #7. Not sure that's the right thing to do.

Btw. symName does NOT override anything. There is another symName with two arguments in the parent, but giving a third argument a default in the child does not override the parent's two argument version.
